### PR TITLE
修正InputMethod传入参数错误

### DIFF
--- a/lesscode-core/src/main/java/com/jayfeng/lesscode/core/KeyBoardLess.java
+++ b/lesscode-core/src/main/java/com/jayfeng/lesscode/core/KeyBoardLess.java
@@ -17,7 +17,7 @@ public final class KeyBoardLess {
     public static void $show(Context context, View view) {
         InputMethodManager imm =
                 (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-        imm.showSoftInput(view, InputMethodManager.RESULT_SHOWN);
+        imm.showSoftInput(view, InputMethodManager.SHOW_FORCED);
         imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
     }
 


### PR DESCRIPTION
虽然两个常量值一样，但是还是用
···
InputMethodManager.SHOW_FORCED
···
逻辑上比较正确一点。
