### PR TITLE
避免$.sTag存在时无用的代码

### DIFF
--- a/lesscode-core/src/main/java/com/jayfeng/lesscode/core/LogLess.java
+++ b/lesscode-core/src/main/java/com/jayfeng/lesscode/core/LogLess.java
@@ -124,16 +124,16 @@ public final class LogLess {
     }
 
     /**
-     * 自动从StackTrace中取TAG
+     * 如果$.sTAG是空则自动从StackTrace中取TAG
      *
      * @return
      */
     private static String getTag() {
-        StackTraceElement caller = new Throwable().fillInStackTrace().getStackTrace()[2];
-        if (TextUtils.isEmpty($.sTAG)) {
-            return caller.getFileName();
+        if (!TextUtils.isEmpty($.sTAG)) {
+            return $.sTAG;
         }
-        return $.sTAG;
+        StackTraceElement caller = new Throwable().fillInStackTrace().getStackTrace()[2];
+        return caller.getFileName();
     }
 
     /**


### PR DESCRIPTION
reorder LogLess getTag() code so that we can avoid creating Throwable every time when $.sTag has already defined.

new Throwable().fillInStackTrace().getStackTrace()[2];
fillInStackTrace()还是有点耗时的 ^_^。
所以能不调用还是不调用吧。
